### PR TITLE
Use more accurate lower bound on base

### DIFF
--- a/invertible-grammar.cabal
+++ b/invertible-grammar.cabal
@@ -36,7 +36,7 @@ library
     Data.InvertibleGrammar.Monad
 
   build-depends:
-      base              >=4.7   && <5.0
+      base              >=4.8   && <5.0
     , bifunctors        >=4.2   && <5.6
     , containers        >=0.5.5 && <0.7
     , mtl               >=2.1   && <2.3


### PR DESCRIPTION
As can be ssen on https://matrix.hackage.haskell.org/package/invertible-grammar@1549660096 this
package isn't compatible with base-4.7 despite the `.cabal` file advertising compatibility with base-4.7.

I've already fixed up the 3 affected releases via  [Hackage metadata revisions](https://github.com/haskell-infra/hackage-trustees/blob/master/revisions-information.md) at

 - https://hackage.haskell.org/package/invertible-grammar-0.1.0/revisions/
 - https://hackage.haskell.org/package/invertible-grammar-0.1.1/revisions/
 - https://hackage.haskell.org/package/invertible-grammar-0.1.2/revisions/

and there's no need to upload a new release as the metadata issue has been addressed.

You can inspect the resulting build-plans at

https://matrix.hackage.haskell.org/package/invertible-grammar@1549733763


